### PR TITLE
Feat history

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -87,4 +87,5 @@
     </plugin>
     <plugin name="cordova-plugin-x-toast" spec="2.7.2" />
     <engine name="android" spec="7.1.4" />
+    <plugin name="cordova-sqlite-storage" spec="2.6.0" />
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -86,6 +86,8 @@
         <variable name="ANDROID_SUPPORT_V4_VERSION" value="27.+" />
     </plugin>
     <plugin name="cordova-plugin-x-toast" spec="2.7.2" />
-    <engine name="android" spec="7.1.4" />
     <plugin name="cordova-sqlite-storage" spec="2.6.0" />
+    <plugin name="cordova-plugin-nativestorage" spec="2.3.2" />
+    <engine name="android" spec="7.1.4" />
+    <engine name="browser" spec="5.0.4" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1506,6 +1506,19 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-x-toast/-/cordova-plugin-x-toast-2.7.2.tgz",
       "integrity": "sha512-nx4LaBkJyEk1MknkLC0/U904A42WX/1/OZUeUyXkKRtChShsoTdbWlvEqHKzPbELzf2bEMnXd1CI70WRv+a4hA=="
     },
+    "cordova-sqlite-storage": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cordova-sqlite-storage/-/cordova-sqlite-storage-2.6.0.tgz",
+      "integrity": "sha512-m+KylFwNRsQloJ6TZihupfma2muXkmNglh8cFSiJQqriTTm6eq0gyPaAuKxgoPswe679G+0aUai07NFC/f0GGQ==",
+      "requires": {
+        "cordova-sqlite-storage-dependencies": "1.2.1"
+      }
+    },
+    "cordova-sqlite-storage-dependencies": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cordova-sqlite-storage-dependencies/-/cordova-sqlite-storage-dependencies-1.2.1.tgz",
+      "integrity": "sha512-4ihQApBGVKR1QZ4oOSGctKFfthtCfiWMTcIIfxe97vKxlvGr9NyXOvYG9vXU9S7yVR7Ua+Rj47hkE7pQIKvQTg=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,11 @@
       "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-4.18.0.tgz",
       "integrity": "sha512-J9Vz9YhKHRU+xw2C80PJrtfz/8njKl+muRynFfAM+auI4cp+WX89klzOCmkhZHv8UwVZyVEZaXrPoIEohEX7Aw=="
     },
+    "@ionic-native/native-storage": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/native-storage/-/native-storage-4.19.0.tgz",
+      "integrity": "sha512-ycB2QzRVcnc4rzbLenQSWFouRFzzbRP37DzaQD6xy/SCW5zOQu+ij1/3kj5H4IoobK9LoJHCUjhuguUBKEPuSA=="
+    },
     "@ionic-native/splash-screen": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/@ionic-native/splash-screen/-/splash-screen-4.18.0.tgz",
@@ -281,16 +286,6 @@
         "@ionic/utils-fs": "0.0.6",
         "chalk": "2.4.1",
         "express": "4.16.4",
-        "tslib": "1.9.3"
-      }
-    },
-    "@ionic/storage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ionic/storage/-/storage-2.2.0.tgz",
-      "integrity": "sha512-2pszrzmI+fAar2Rx0WmJDVpc15D1k5tvLkB49NLYWJ2pOMaO/3/vp7mg/mEbg3rdsPE9FRbYI6vdKjQ2pP1EWA==",
-      "requires": {
-        "localforage": "1.7.1",
-        "localforage-cordovasqlitedriver": "1.7.0",
         "tslib": "1.9.3"
       }
     },
@@ -1471,6 +1466,661 @@
         }
       }
     },
+    "cordova-browser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cordova-browser/-/cordova-browser-5.0.4.tgz",
+      "integrity": "sha512-EDuG+9NGsaYpNSY6wF0kR34m1m38V+nRglGXxQ609fgMYrMHEYR2lg38nDr1Os4qeF0LJz8UQ7nq7Y+idg6Aig==",
+      "requires": {
+        "abbrev": "1.1.1",
+        "accepts": "1.3.5",
+        "ansi": "0.3.1",
+        "ansi-regex": "2.1.1",
+        "ansi-styles": "2.2.1",
+        "array-flatten": "1.1.1",
+        "balanced-match": "1.0.0",
+        "base64-js": "1.2.0",
+        "big-integer": "1.6.32",
+        "body-parser": "1.18.2",
+        "bplist-parser": "0.1.1",
+        "brace-expansion": "1.1.11",
+        "bytes": "3.0.0",
+        "chalk": "1.1.3",
+        "compressible": "2.0.14",
+        "compression": "1.7.2",
+        "concat-map": "0.0.1",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "cordova-common": "2.2.5",
+        "cordova-registry-mapper": "1.1.15",
+        "cordova-serve": "2.0.1",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "ee-first": "1.1.1",
+        "elementtree": "0.1.6",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "escape-string-regexp": "1.0.5",
+        "etag": "1.8.1",
+        "express": "4.16.3",
+        "finalhandler": "1.1.1",
+        "forwarded": "0.1.2",
+        "fresh": "0.5.2",
+        "glob": "5.0.15",
+        "has-ansi": "2.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.19",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ipaddr.js": "1.6.0",
+        "is-wsl": "1.1.0",
+        "media-typer": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "mime": "1.4.1",
+        "mime-db": "1.33.0",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "ms": "2.0.0",
+        "negotiator": "0.6.1",
+        "nopt": "3.0.6",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1",
+        "once": "1.4.0",
+        "opn": "5.3.0",
+        "parseurl": "1.3.2",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "plist": "2.1.0",
+        "proxy-addr": "2.0.3",
+        "q": "1.5.1",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "raw-body": "2.3.2",
+        "safe-buffer": "5.1.1",
+        "sax": "0.3.5",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "shelljs": "0.5.3",
+        "statuses": "1.4.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0",
+        "type-is": "1.6.16",
+        "underscore": "1.9.1",
+        "unorm": "1.4.1",
+        "unpipe": "1.0.0",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2",
+        "wrappy": "1.0.2",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "mime-types": "2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "ansi": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "big-integer": {
+          "version": "1.6.32",
+          "bundled": true
+        },
+        "body-parser": {
+          "version": "1.18.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "bplist-parser": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "big-integer": "1.6.32"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "compressible": {
+          "version": "2.0.14",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.34.0"
+          },
+          "dependencies": {
+            "mime-db": {
+              "version": "1.34.0",
+              "bundled": true
+            }
+          }
+        },
+        "compression": {
+          "version": "1.7.2",
+          "bundled": true,
+          "requires": {
+            "accepts": "1.3.5",
+            "bytes": "3.0.0",
+            "compressible": "2.0.14",
+            "debug": "2.6.9",
+            "on-headers": "1.0.1",
+            "safe-buffer": "5.1.1",
+            "vary": "1.1.2"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "cordova-common": {
+          "version": "2.2.5",
+          "bundled": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "bplist-parser": "0.1.1",
+            "cordova-registry-mapper": "1.1.15",
+            "elementtree": "0.1.6",
+            "glob": "5.0.15",
+            "minimatch": "3.0.4",
+            "plist": "2.1.0",
+            "q": "1.5.1",
+            "shelljs": "0.5.3",
+            "underscore": "1.9.1",
+            "unorm": "1.4.1"
+          }
+        },
+        "cordova-registry-mapper": {
+          "version": "1.1.15",
+          "bundled": true
+        },
+        "cordova-serve": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "compression": "1.7.2",
+            "express": "4.16.3",
+            "opn": "5.3.0",
+            "shelljs": "0.5.3"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "elementtree": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "sax": "0.3.5"
+          }
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "express": {
+          "version": "4.16.3",
+          "bundled": true,
+          "requires": {
+            "accepts": "1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "2.0.3",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.4.0",
+            "type-is": "1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
+            "unpipe": "1.0.0"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "bundled": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "depd": "1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.4.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "mime": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "opn": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "is-wsl": "1.1.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "plist": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.27"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "forwarded": "0.1.2",
+            "ipaddr.js": "1.6.0"
+          }
+        },
+        "q": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "0.3.5",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.16.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.3",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
+          }
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "bundled": true
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.18"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "bundled": true
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xmlbuilder": {
+          "version": "8.2.2",
+          "bundled": true
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "bundled": true
+        }
+      }
+    },
     "cordova-plugin-device": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-2.0.2.tgz",
@@ -1485,6 +2135,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-2.3.1.tgz",
       "integrity": "sha512-tGKRp2iEYbOwZ2sT/uBU2C1YW1a43QI3YGi4WMH4LsgUdDjYGj4OZ8o7xQtRlxOKpdAjtSyLn1wz3Jip04elMg=="
+    },
+    "cordova-plugin-nativestorage": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-nativestorage/-/cordova-plugin-nativestorage-2.3.2.tgz",
+      "integrity": "sha512-olg/BzYRk0NGbKQ5f7rf21RYQEyJI19CCZn6RpVMO9/kbRRFqae/6ixjDNy81dXSu2TQ42brjBddGe1Qpn5ViA=="
     },
     "cordova-plugin-splashscreen": {
       "version": "5.0.2",
@@ -1505,19 +2160,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-x-toast/-/cordova-plugin-x-toast-2.7.2.tgz",
       "integrity": "sha512-nx4LaBkJyEk1MknkLC0/U904A42WX/1/OZUeUyXkKRtChShsoTdbWlvEqHKzPbELzf2bEMnXd1CI70WRv+a4hA=="
-    },
-    "cordova-sqlite-storage": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cordova-sqlite-storage/-/cordova-sqlite-storage-2.6.0.tgz",
-      "integrity": "sha512-m+KylFwNRsQloJ6TZihupfma2muXkmNglh8cFSiJQqriTTm6eq0gyPaAuKxgoPswe679G+0aUai07NFC/f0GGQ==",
-      "requires": {
-        "cordova-sqlite-storage-dependencies": "1.2.1"
-      }
-    },
-    "cordova-sqlite-storage-dependencies": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cordova-sqlite-storage-dependencies/-/cordova-sqlite-storage-dependencies-1.2.1.tgz",
-      "integrity": "sha512-4ihQApBGVKR1QZ4oOSGctKFfthtCfiWMTcIIfxe97vKxlvGr9NyXOvYG9vXU9S7yVR7Ua+Rj47hkE7pQIKvQTg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3090,11 +3732,6 @@
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3555,14 +4192,6 @@
         "invert-kv": "1.0.0"
       }
     },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "requires": {
-        "immediate": "3.0.6"
-      }
-    },
     "livereload-js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
@@ -3597,22 +4226,6 @@
         "big.js": "5.2.2",
         "emojis-list": "2.1.0",
         "json5": "1.0.1"
-      }
-    },
-    "localforage": {
-      "version": "1.7.1",
-      "resolved": "http://registry.npmjs.org/localforage/-/localforage-1.7.1.tgz",
-      "integrity": "sha1-5JJ+BCMCuGTbMPMhHxO1xvDell0=",
-      "requires": {
-        "lie": "3.1.1"
-      }
-    },
-    "localforage-cordovasqlitedriver": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/localforage-cordovasqlitedriver/-/localforage-cordovasqlitedriver-1.7.0.tgz",
-      "integrity": "sha1-i5OVd1nuaI06WNW6fAR39sy1ODg=",
-      "requires": {
-        "localforage": "1.7.1"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cordova-plugin-statusbar": "^2.4.2",
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-plugin-x-toast": "2.7.2",
+    "cordova-sqlite-storage": "2.6.0",
     "ionic-angular": "3.9.2",
     "ionicons": "3.0.0",
     "phonegap-plugin-barcodescanner": "8.0.1",
@@ -60,7 +61,8 @@
       "cordova-plugin-ionic-webview": {
         "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
       },
-      "cordova-plugin-ionic-keyboard": {}
+      "cordova-plugin-ionic-keyboard": {},
+      "cordova-sqlite-storage": {}
     },
     "platforms": [
       "android"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,16 @@
     "@angular/platform-browser-dynamic": "5.2.11",
     "@ionic-native/barcode-scanner": "^4.18.0",
     "@ionic-native/core": "~4.18.0",
+    "@ionic-native/native-storage": "^4.19.0",
     "@ionic-native/splash-screen": "~4.18.0",
     "@ionic-native/status-bar": "~4.18.0",
     "@ionic-native/toast": "^4.18.0",
-    "@ionic/storage": "2.2.0",
     "cordova-android": "7.1.4",
+    "cordova-browser": "5.0.4",
     "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-ionic-keyboard": "^2.1.3",
     "cordova-plugin-ionic-webview": "^2.3.1",
+    "cordova-plugin-nativestorage": "2.3.2",
     "cordova-plugin-splashscreen": "^5.0.2",
     "cordova-plugin-statusbar": "^2.4.2",
     "cordova-plugin-whitelist": "^1.3.3",
@@ -62,10 +64,11 @@
         "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
       },
       "cordova-plugin-ionic-keyboard": {},
-      "cordova-sqlite-storage": {}
+      "cordova-plugin-nativestorage": {}
     },
     "platforms": [
-      "android"
+      "android",
+      "browser"
     ]
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,8 @@ import { BarcodeScanner } from '@ionic-native/barcode-scanner';
 import { Toast } from '@ionic-native/toast';
 //Add simple module to provide http methods
 import { HttpModule } from '@angular/http';
+//Add storage module to provide sqllite storage
+import { NativeStorage } from '@ionic-native/native-storage';
 
 import { MyApp } from './app.component';
 import { HomePage } from '../pages/home/home';
@@ -18,6 +20,7 @@ import { ProductPage } from '../pages/product/product';
 import { DataServiceProvider } from '../providers/data-service/data-service';
 import { ProductPageModule } from '../pages/product/product.module';
 import { ViewedProductsProvider } from '../providers/viewed-products/viewed-products';
+import { HistoryPageModule } from '../pages/history/history.module';
 
 @NgModule({
   declarations: [
@@ -29,6 +32,7 @@ import { ViewedProductsProvider } from '../providers/viewed-products/viewed-prod
     IonicModule.forRoot(MyApp),
     HttpModule,
     ProductPageModule,
+    HistoryPageModule,
   ],
   bootstrap: [IonicApp],
   entryComponents: [
@@ -43,6 +47,7 @@ import { ViewedProductsProvider } from '../providers/viewed-products/viewed-prod
     BarcodeScanner,
     Toast,
     DataServiceProvider,
+    NativeStorage,
     ViewedProductsProvider
   ]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { ProductPage } from '../pages/product/product';
 
 import { DataServiceProvider } from '../providers/data-service/data-service';
 import { ProductPageModule } from '../pages/product/product.module';
+import { ViewedProductsProvider } from '../providers/viewed-products/viewed-products';
 
 @NgModule({
   declarations: [
@@ -41,7 +42,8 @@ import { ProductPageModule } from '../pages/product/product.module';
     {provide: ErrorHandler, useClass: IonicErrorHandler},
     BarcodeScanner,
     Toast,
-    DataServiceProvider
+    DataServiceProvider,
+    ViewedProductsProvider
   ]
 })
 export class AppModule {}

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -1,11 +1,13 @@
 export class Product {
+    readonly isbn: string
     readonly name: string;
     readonly exist: boolean;
     readonly isOk: boolean;
     readonly listOfViolations: string[];
     readonly imageUrl: string;
 
-    constructor(name: string, exist: boolean, isOk: boolean, listOfViolations: string[], imageUrl: string) {
+    constructor(isbn: string, name: string, exist: boolean, isOk: boolean, listOfViolations: string[], imageUrl: string) {
+        this.isbn = isbn;
         this.name = name;
         this.exist = exist;
         this.isOk = isOk;

--- a/src/pages/history/history.html
+++ b/src/pages/history/history.html
@@ -15,24 +15,12 @@
 
 <ion-content padding>
   <ion-list>
-    <ion-item *ngFor="let product of viewedProducts" (click)="viewProduct(element)" ng-style="{ background: product.isOk == 'true' ? 'lightblue' : 'lightgreen' }">
+    <ion-item *ngFor="let product of viewedProducts" (click)="viewProduct(product)"
+    [ngStyle]="{ background: product.isOk ? '#33FF93': '#FF5733'}">
       <ion-avatar item-left>
         <ion-img [src]="product.imageUrl"></ion-img>
       </ion-avatar>
       <h2>{{product.name}}</h2>
-
-      <ul>
-        <li *ngFor="let violation of product.listOfViolations">
-          {{violation}}
-        </li>
-      </ul>
-    </ion-item>
-
-    <ion-item>
-      <div id="main" class="product-image-container">
-        <img src="./assets/imgs/nok.svg" alt="" class="product-image-overlay">
-        <img [src]="product?.imageUrl" alt="" class="product-image">
-      </div>
     </ion-item>
   </ion-list>
 </ion-content>

--- a/src/pages/history/history.html
+++ b/src/pages/history/history.html
@@ -1,0 +1,38 @@
+<!--
+  Generated template for the HistoryPage page.
+
+  See http://ionicframework.com/docs/components/#navigation for more info on
+  Ionic pages and navigation.
+-->
+<ion-header>
+
+  <ion-navbar>
+    <ion-title>historique</ion-title>
+  </ion-navbar>
+
+</ion-header>
+
+
+<ion-content padding>
+  <ion-list>
+    <ion-item *ngFor="let product of viewedProducts" (click)="viewProduct(element)" ng-style="{ background: product.isOk == 'true' ? 'lightblue' : 'lightgreen' }">
+      <ion-avatar item-left>
+        <ion-img [src]="product.imageUrl"></ion-img>
+      </ion-avatar>
+      <h2>{{product.name}}</h2>
+
+      <ul>
+        <li *ngFor="let violation of product.listOfViolations">
+          {{violation}}
+        </li>
+      </ul>
+    </ion-item>
+
+    <ion-item>
+      <div id="main" class="product-image-container">
+        <img src="./assets/imgs/nok.svg" alt="" class="product-image-overlay">
+        <img [src]="product?.imageUrl" alt="" class="product-image">
+      </div>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/pages/history/history.module.ts
+++ b/src/pages/history/history.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { HistoryPage } from './history';
+
+@NgModule({
+  declarations: [
+    HistoryPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(HistoryPage),
+  ],
+})
+export class HistoryPageModule {}

--- a/src/pages/history/history.scss
+++ b/src/pages/history/history.scss
@@ -1,0 +1,3 @@
+page-history {
+
+}

--- a/src/pages/history/history.ts
+++ b/src/pages/history/history.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { Product } from '../../models/product';
 import { ViewedProductsProvider } from '../../providers/viewed-products/viewed-products';
+import { ProductPage } from '../product/product';
 
 /**
  * Generated class for the HistoryPage page.
@@ -16,8 +17,7 @@ import { ViewedProductsProvider } from '../../providers/viewed-products/viewed-p
   templateUrl: 'history.html',
 })
 export class HistoryPage {
-
-  viewedProducts : [Product,viewColor[]
+  viewedProducts : Product[]
 
   constructor(public navCtrl: NavController, public navParams: NavParams, 
     public viewedProvider : ViewedProductsProvider) {
@@ -29,6 +29,11 @@ export class HistoryPage {
 
   ionViewDidLoad() {
     console.log('ionViewDidLoad HistoryPage');
+  }
+
+  viewProduct(product : Product){
+    console.log("viewing product from history", product);
+    this.navCtrl.push(ProductPage, { product: product});
   }
 
 }

--- a/src/pages/history/history.ts
+++ b/src/pages/history/history.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import { Product } from '../../models/product';
+import { ViewedProductsProvider } from '../../providers/viewed-products/viewed-products';
+
+/**
+ * Generated class for the HistoryPage page.
+ *
+ * See https://ionicframework.com/docs/components/#navigation for more info on
+ * Ionic pages and navigation.
+ */
+
+@IonicPage()
+@Component({
+  selector: 'page-history',
+  templateUrl: 'history.html',
+})
+export class HistoryPage {
+
+  viewedProducts : [Product,viewColor[]
+
+  constructor(public navCtrl: NavController, public navParams: NavParams, 
+    public viewedProvider : ViewedProductsProvider) {
+      // asynchronously update the list of viewedProducts
+      this.viewedProvider.getAllViewed().then(viewed => {
+        this.viewedProducts = viewed;
+      });
+  }
+
+  ionViewDidLoad() {
+    console.log('ionViewDidLoad HistoryPage');
+  }
+
+}

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -6,6 +6,7 @@ import { Toast } from '@ionic-native/toast';
 import { DataServiceProvider } from '../../providers/data-service/data-service';
 import { ProductPage } from '../product/product';
 import { Product } from '../../models/product';
+import { ViewedProductsProvider } from '../../providers/viewed-products/viewed-products';
 
 @Component({
     selector: 'page-home',
@@ -17,7 +18,9 @@ export class HomePage {
         public navParams: NavParams,
         private barcodeScanner: BarcodeScanner,
         private toast: Toast,
-        public dataService: DataServiceProvider) {
+        public dataService: DataServiceProvider,
+        public viewedProducts: ViewedProductsProvider,
+        ) {
         // dirty hook to allow scanning directly when going to this page
         if (this.navParams.get('doScan')) {
             this.scan();
@@ -29,6 +32,7 @@ export class HomePage {
         // this.dataService.getFoodProduct("737628064502")
         //     .subscribe((p) => {
         //         if (p.exist) {
+        //             this.viewedProducts.addViewed(p);
         //             this.navCtrl.push(ProductPage, { product: p });
         //             console.log("warning: Using test food mock")
         //         }
@@ -36,6 +40,7 @@ export class HomePage {
         // this.dataService.getBeautyProduct("737628064502")
         //     .subscribe((p) => {
         //         if (p.exist) {
+        //             this.viewedProducts.addViewed(p);
         //             this.navCtrl.push(ProductPage, { product: p });
         //             console.log("warning: Using test beauty mock")
         //         }
@@ -46,6 +51,7 @@ export class HomePage {
             this.dataService.getFoodProduct(barcodeData.text)
                 .subscribe((p) => {
                     if (p.exist) {
+                        this.viewedProducts.addViewed(p);
                         this.navCtrl.push(ProductPage, { product: p });
                     }
                 });
@@ -53,6 +59,7 @@ export class HomePage {
             this.dataService.getBeautyProduct(barcodeData.text)
                 .subscribe((p) => {
                     if (p.exist) {
+                        this.viewedProducts.addViewed(p);
                         this.navCtrl.push(ProductPage, { product: p });
                     }
                 });

--- a/src/pages/product/product.ts
+++ b/src/pages/product/product.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { Product } from '../../models/product';
 import { HomePage } from '../home/home';
+import { HistoryPage } from '../history/history';
 
 /**
  * Generated class for the ProductPage page.
@@ -30,7 +31,7 @@ export class ProductPage {
 
   navToHistory(){
     console.log('todo : navToHistory');
-    this.navCtrl.push(HomePage);
+    this.navCtrl.push(HistoryPage);
     //this.navCtrl.push(HistoryPage)
   }
 

--- a/src/providers/data-service/data-service.ts
+++ b/src/providers/data-service/data-service.ts
@@ -19,22 +19,22 @@ export class DataServiceProvider {
 
     getFoodProduct(isbn: string): Observable<Product> {
         return this.http.get('https://world.openfoodfacts.org/api/v0/product/' + isbn + '.json')
-            .map((res: Response) => this.buildProduct(res.json()));
+            .map((res: Response) => this.buildProduct(isbn, res.json()));
     }
 
     getBeautyProduct(isbn: string): Observable<Product> {
         return this.http.get('https://world.openbeautyfacts.org/api/v0/product/' + isbn + '.json')
-            .map((res: Response) => this.buildProduct(res.json()));
+            .map((res: Response) => this.buildProduct(isbn, res.json()));
     }
 
 
-    private buildProduct(payload: any[]) {
+    private buildProduct(isbn :string, payload: any[]) {
         if (payload == undefined || payload['status'] === 0) {
             console.log("Product doesn't exist in database")
-            return new Product("Inconnu", false, false, [], "");
+            return new Product(isbn, "Inconnu", false, false, [], "");
         } else if (payload['product'] == undefined || payload['product']['product_name'] == undefined || payload['product']['product_name'].length === 0) {
             console.log("Product malformed")
-            return new Product("Inconnu", false, false, [], "");
+            return new Product(isbn, "Inconnu", false, false, [], "");
         }
 
         let forbiddenIngredients = this.bannedIngredients
@@ -42,7 +42,9 @@ export class DataServiceProvider {
                 return payload['product']['ingredients_tags'].indexOf(ingredient) > -1;
             });
 
-        return new Product(payload['product']['product_name'],
+        return new Product(
+            isbn,
+            payload['product']['product_name'],
             true,
             forbiddenIngredients.length === 0,
             forbiddenIngredients,

--- a/src/providers/viewed-products/viewed-products.ts
+++ b/src/providers/viewed-products/viewed-products.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Storage } from '@ionic/storage';
+import { Product } from '../../models/product';
+
+const STORAGE_KEY = 'viewedProducts';
+
+@Injectable()
+export class ViewedProductsProvider {
+
+  constructor(public http: HttpClient, public storage: Storage) {
+    console.log('ViewedProductsProvider Provider conructed');
+  }
+
+  isViewed(product: Product): Promise<boolean> {
+    return this.getAllViewed().then(result => {
+      return result && result.indexOf(product) !== -1;
+    });
+  }
+
+  addViewed(product: Product): Promise<any> {
+    return this.getAllViewed().then(result => {
+      if (result) {
+        result.push(product);
+        return this.storage.set(STORAGE_KEY, result);
+      } else {
+        return this.storage.set(STORAGE_KEY, [product]);
+      }
+    });
+  }
+
+  removeViewed(product: Product): Promise<any> {
+    return this.getAllViewed().then(result => {
+      if (result) {
+        var index = result.indexOf(product);
+        result.splice(index, 1);
+        return this.storage.set(STORAGE_KEY, result);
+      }
+    });
+  }
+
+  getAllViewed(): Promise<Product[]> {
+    return this.storage.get(STORAGE_KEY);
+  }
+}

--- a/src/providers/viewed-products/viewed-products.ts
+++ b/src/providers/viewed-products/viewed-products.ts
@@ -1,6 +1,5 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Storage } from '@ionic/storage';
+import { NativeStorage } from '@ionic-native/native-storage';
 import { Product } from '../../models/product';
 
 const STORAGE_KEY = 'viewedProducts';
@@ -8,7 +7,7 @@ const STORAGE_KEY = 'viewedProducts';
 @Injectable()
 export class ViewedProductsProvider {
 
-  constructor(public http: HttpClient, public storage: Storage) {
+  constructor(private storage: NativeStorage) {
     console.log('ViewedProductsProvider Provider conructed');
   }
 
@@ -19,27 +18,46 @@ export class ViewedProductsProvider {
   }
 
   addViewed(product: Product): Promise<any> {
+    console.log("adding a product to viewed", product);
     return this.getAllViewed().then(result => {
       if (result) {
         result.push(product);
-        return this.storage.set(STORAGE_KEY, result);
+        return this.storage.setItem(STORAGE_KEY, result);
       } else {
-        return this.storage.set(STORAGE_KEY, [product]);
+        return this.storage.setItem(STORAGE_KEY, [product]);
+      }
+    });
+  }
+
+  addViewedUnique(product: Product): Promise<any> {
+    console.log("adding a product to viewed without redundancy", product);
+    return this.getAllViewed().then(result => {
+      if (result) {
+        // produc already in the list
+        if (result.indexOf(product) != -1) {
+          return Promise.resolve(product);
+        }
+        result.push(product);
+        return this.storage.setItem(STORAGE_KEY, result);
+      } else {
+        return this.storage.setItem(STORAGE_KEY, [product]);
       }
     });
   }
 
   removeViewed(product: Product): Promise<any> {
+    console.log("removing a product from viewed", product);
     return this.getAllViewed().then(result => {
       if (result) {
         var index = result.indexOf(product);
         result.splice(index, 1);
-        return this.storage.set(STORAGE_KEY, result);
+        return this.storage.setItem(STORAGE_KEY, result);
       }
     });
   }
 
   getAllViewed(): Promise<Product[]> {
-    return this.storage.get(STORAGE_KEY);
+    return this.storage.getItem(STORAGE_KEY)
+    .catch(error => console.log("could not fetch value from storage",STORAGE_KEY, this.storage, ));
   }
 }


### PR DESCRIPTION
An ugly history page just for demo.

 - All scans are saved, but I also provide a deduplicated save function if we only want one copy of each product on the history.

 - Idea : merge history and product page in a list with growing/shrinking cards (when you click them).

 - structure : push scan events (with a date and maybe a location) to the history and display scan event on the list (and on click, grow the scan event to display the full product page).